### PR TITLE
refactor(follow): Follow 엔티티 키 전략 변경

### DIFF
--- a/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
@@ -21,9 +21,14 @@ import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode
 @Entity
 @Table(
     name = "follow",
-    uniqueConstraints
-            = @UniqueConstraint(name = "uq_follower_id_followee_id", columnNames = {"follower_id", "followee_id"}),
-    check = @CheckConstraint(name = "follower_must_different_from_followee", constraint = "follower_id <> followee_id")
+    uniqueConstraints = @UniqueConstraint(
+            name = "uq_follower_id_followee_id",
+            columnNames = {"follower_id", "followee_id"}
+    ),
+    check = @CheckConstraint(
+            name = "follower_must_different_from_followee",
+            constraint = "follower_id <> followee_id"
+    )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends CreationAuditEntity {

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
@@ -4,15 +4,16 @@ import com.gorogoro.followandlike.common.domain.entity.CreationAuditEntity;
 import com.gorogoro.followandlike.follow.domain.exception.FollowException;
 import jakarta.persistence.CheckConstraint;
 import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
 import java.util.Objects;
 
 import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode.*;
@@ -20,20 +21,49 @@ import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode
 @Entity
 @Table(
     name = "follow",
+    uniqueConstraints
+            = @UniqueConstraint(name = "uq_follower_id_followee_id", columnNames = {"follower_id", "followee_id"}),
     check = @CheckConstraint(name = "follower_must_different_from_followee", constraint = "follower_id <> followee_id")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Follow extends CreationAuditEntity {
 
-    @EmbeddedId
-    @Getter
-    private WhoFollowsWhom id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    public Follow(WhoFollowsWhom id) {
-        if (id == null) {
-            throw new FollowException(ID_IS_NULL);
+    @Column(nullable = false)
+    @Getter
+    private Long followerId;
+
+    @Column(nullable = false)
+    @Getter
+    private Long followeeId;
+
+    public Follow(Long followerId, Long followeeId) {
+
+        validate(followerId, followeeId);
+
+        this.followerId = followerId;
+        this.followeeId = followeeId;
+    }
+
+    private void validate(Long followerId, Long followeeId) {
+        if (followerId == null) {
+            throw new FollowException(FOLLOWER_ID_IS_NULL);
         }
-        this.id = id;
+        if (followeeId == null) {
+            throw new FollowException(FOLLOWEE_ID_IS_NULL);
+        }
+        if (followerId < 0) {
+            throw new FollowException(FOLLOWER_ID_IS_NEGATIVE);
+        }
+        if (followeeId < 0) {
+            throw new FollowException(FOLLOWEE_ID_IS_NEGATIVE);
+        }
+        if (followerId.equals(followeeId)) {
+            throw new FollowException(FOLLOWED_ONESELF);
+        }
     }
 
     @Override
@@ -45,57 +75,5 @@ public class Follow extends CreationAuditEntity {
     @Override
     public int hashCode() {
         return Objects.hashCode(id);
-    }
-
-    /* ↓ 내부 키 클래스 ↓ */
-
-    @Embeddable
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class WhoFollowsWhom implements Serializable {
-
-        @Column(nullable = false)
-        @Getter
-        private Long followerId;
-
-        @Column(nullable = false)
-        @Getter
-        private Long followeeId;
-
-        public WhoFollowsWhom(Long followerId, Long followeeId) {
-
-            validate(followerId, followeeId);
-
-            this.followerId = followerId;
-            this.followeeId = followeeId;
-        }
-
-        private void validate(Long followerId, Long followeeId) {
-            if (followerId == null) {
-                throw new FollowException(FOLLOWER_ID_IS_NULL);
-            }
-            if (followeeId == null) {
-                throw new FollowException(FOLLOWEE_ID_IS_NULL);
-            }
-            if (followerId < 0) {
-                throw new FollowException(FOLLOWER_ID_IS_NEGATIVE);
-            }
-            if (followeeId < 0) {
-                throw new FollowException(FOLLOWEE_ID_IS_NEGATIVE);
-            }
-            if (followerId.equals(followeeId)) {
-                throw new FollowException(FOLLOWED_ONESELF);
-            }
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!(o instanceof WhoFollowsWhom that)) return false;
-            return Objects.equals(followerId, that.followerId) && Objects.equals(followeeId, that.followeeId);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(followerId, followeeId);
-        }
     }
 }

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/entity/Follow.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -28,6 +29,10 @@ import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode
     check = @CheckConstraint(
             name = "follower_must_different_from_followee",
             constraint = "follower_id <> followee_id"
+    ),
+    indexes = @Index(
+            name = "idx_followee_id",
+            columnList = "followee_id"
     )
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
@@ -6,12 +6,11 @@ import lombok.Getter;
 public enum FollowErrorCode {
 
     // CREATION_ERROR: 0xx
-    ID_IS_NULL("001", "id 가 null 입니다."),
-    FOLLOWER_ID_IS_NULL("002", "followerId 가 null 입니다."),
-    FOLLOWER_ID_IS_NEGATIVE("003", "followerId 가 음수입니다."),
-    FOLLOWEE_ID_IS_NULL("004", "followeeId 가 null 입니다."),
-    FOLLOWEE_ID_IS_NEGATIVE("005", "followeeId 가 음수입니다."),
-    FOLLOWED_ONESELF("006", "자기자신을 팔로우할 수 없습니다. followerId 와 followeeId 가 같습니다.");
+    FOLLOWER_ID_IS_NULL("001", "followerId 가 null 입니다."),
+    FOLLOWER_ID_IS_NEGATIVE("002", "followerId 가 음수입니다."),
+    FOLLOWEE_ID_IS_NULL("003", "followeeId 가 null 입니다."),
+    FOLLOWEE_ID_IS_NEGATIVE("004", "followeeId 가 음수입니다."),
+    FOLLOWED_ONESELF("005", "자기자신을 팔로우할 수 없습니다. followerId 와 followeeId 가 같습니다.");
 
     private final String code;
     private final String message;

--- a/src/test/java/com/gorogoro/followandlike/follow/domain/entity/FollowTest.java
+++ b/src/test/java/com/gorogoro/followandlike/follow/domain/entity/FollowTest.java
@@ -1,6 +1,5 @@
 package com.gorogoro.followandlike.follow.domain.entity;
 
-import com.gorogoro.followandlike.follow.domain.entity.Follow.WhoFollowsWhom;
 import com.gorogoro.followandlike.follow.domain.exception.FollowException;
 import org.junit.jupiter.api.Test;
 
@@ -10,32 +9,25 @@ import static org.junit.jupiter.api.Assertions.*;
 class FollowTest {
 
     @Test
-    void shouldSuccess_whenEntityCreation_givenIdsIsValidlyDifferent() {
-        WhoFollowsWhom id = new WhoFollowsWhom(1L, 2L);
-        Follow follow = new Follow(id);
+    void shouldSuccess_whenCreation_givenIdsIsValidlyDifferent() {
+        Long followerId = 1L;
+        Long followeeId = 2L;
+        Follow follow = new Follow(followerId, followeeId);
         assertAll(
-                () -> assertEquals(1L, follow.getId().getFollowerId()),
-                () -> assertEquals(2L, follow.getId().getFolloweeId())
+                () -> assertEquals(1L, follow.getFollowerId()),
+                () -> assertEquals(2L, follow.getFolloweeId())
         );
     }
 
     @Test
-    void shouldThrowFollowException_whenEntityCreation_givenIdIsNull() {
+    void shouldThrowFollowException_whenCreation_givenFollowerIdIsSameWithFolloweeId() {
         assertThrows(FollowException.class, () -> {
-            try {
-                new Follow(null);
-            } catch (FollowException e) {
-                assertEquals(ID_IS_NULL, e.getCode());
-                throw e;
-            }
-        });
-    }
 
-    @Test
-    void shouldThrowFollowException_whenEntityCreation_givenFollowerIdIsSameWithFolloweeId() {
-        assertThrows(FollowException.class, () -> {
+            Long followerId = 1L;
+            Long followeeId = followerId;
+
             try {
-                new Follow(new WhoFollowsWhom(1L, 1L));
+                new Follow(followerId, followeeId);
             } catch (FollowException e) {
                 assertEquals(FOLLOWED_ONESELF, e.getCode());
                 throw e;
@@ -44,10 +36,14 @@ class FollowTest {
     }
 
     @Test
-    void shouldThrowFollowException_whenIdCreation_givenFollowerIdIsNull() {
+    void shouldThrowFollowException_whenCreation_givenFollowerIdIsNull() {
         assertThrows(FollowException.class, () -> {
+
+            Long followerId = null;
+            Long followeeId = 1L;
+
             try {
-                new WhoFollowsWhom(null, 1L);
+                new Follow(followerId, followeeId);
             } catch (FollowException e) {
                 assertEquals(FOLLOWER_ID_IS_NULL, e.getCode());
                 throw e;
@@ -56,10 +52,14 @@ class FollowTest {
     }
 
     @Test
-    void shouldThrowFollowException_whenIdCreation_givenFollowerIdIsNegative() {
+    void shouldThrowFollowException_whenCreation_givenFollowerIdIsNegative() {
         assertThrows(FollowException.class, () -> {
+
+            Long followerId = -1L;
+            Long followeeId = 1L;
+
             try {
-                new WhoFollowsWhom(-2L, 1L);
+                new Follow(followerId, followeeId);
             } catch (FollowException e) {
                 assertEquals(FOLLOWER_ID_IS_NEGATIVE, e.getCode());
                 throw e;
@@ -68,10 +68,14 @@ class FollowTest {
     }
 
     @Test
-    void shouldThrowFollowException_whenIdCreation_givenFolloweeIdIsNull() {
+    void shouldThrowFollowException_whenCreation_givenFolloweeIdIsNull() {
         assertThrows(FollowException.class, () -> {
+
+            Long followerId = 1L;
+            Long followeeId = null;
+
             try {
-                new WhoFollowsWhom(1L, null);
+                new Follow(followerId, followeeId);
             } catch (FollowException e) {
                 assertEquals(FOLLOWEE_ID_IS_NULL, e.getCode());
                 throw e;
@@ -80,30 +84,18 @@ class FollowTest {
     }
 
     @Test
-    void shouldThrowFollowException_whenIdCreation_givenFolloweeIdIsNegative() {
+    void shouldThrowFollowException_whenCreation_givenFolloweeIdIsNegative() {
         assertThrows(FollowException.class, () -> {
+
+            Long followerId = 1L;
+            Long followeeId = -1L;
+
             try {
-                new WhoFollowsWhom(1L, -2L);
+                new Follow(followerId, followeeId);
             } catch (FollowException e) {
                 assertEquals(FOLLOWEE_ID_IS_NEGATIVE, e.getCode());
                 throw e;
             }
         });
-    }
-
-    @Test
-    void shouldTwoEntitiesAreIdentical_whenCompareTwoEntity_givenEntitiesWhichHaveSameId() {
-        Follow one = new Follow(new WhoFollowsWhom(1L, 2L));
-        Follow another = new Follow(new WhoFollowsWhom(1L, 2L));
-
-        assertEquals(one, another);
-    }
-
-    @Test
-    void shouldTwoEntitiesAreDifferent_whenCompareTwoEntity_givenEntitiesWhichHaveDifferentId() {
-        Follow one = new Follow(new WhoFollowsWhom(1L, 2L));
-        Follow another = new Follow(new WhoFollowsWhom(2L, 1L));
-
-        assertNotEquals(one, another);
     }
 }


### PR DESCRIPTION
키 전략이 변경된 것에 맞추어 수정함.

기존에는 비즈니스 키를 사용했기 때문에 영속화 전에도 객체 동일성 테스트가 가능했으나 현재는 불가능
이에 리포지토리 구현 이후로 테스트를 미룸

자세한 내용은 아래 이슈 참조

closes #8 