### PR TITLE
feat(follow): Follow 서비스 계층 구현

### DIFF
--- a/src/main/java/com/gorogoro/followandlike/common/domain/exception/BaseDomainException.java
+++ b/src/main/java/com/gorogoro/followandlike/common/domain/exception/BaseDomainException.java
@@ -1,4 +1,4 @@
-package com.gorogoro.followandlike.common.exception;
+package com.gorogoro.followandlike.common.domain.exception;
 
 public class BaseDomainException extends RuntimeException {
 

--- a/src/main/java/com/gorogoro/followandlike/common/domain/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/common/domain/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.gorogoro.followandlike.common.exception;
+package com.gorogoro.followandlike.common.domain.exception;
 
 import org.springframework.http.HttpStatusCode;
 

--- a/src/main/java/com/gorogoro/followandlike/common/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/common/exception/ErrorCode.java
@@ -1,7 +1,9 @@
 package com.gorogoro.followandlike.common.exception;
 
+import org.springframework.http.HttpStatusCode;
+
 public interface ErrorCode {
-    int getHttpStatus();
+    HttpStatusCode getHttpStatus();
     String getHttpStatusMessage();
     String getDomainErrorMessage();
 }

--- a/src/main/java/com/gorogoro/followandlike/common/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/common/exception/ErrorCode.java
@@ -3,7 +3,7 @@ package com.gorogoro.followandlike.common.exception;
 import org.springframework.http.HttpStatusCode;
 
 public interface ErrorCode {
-    HttpStatusCode getHttpStatus();
+    HttpStatusCode getHttpStatusCode();
     String getHttpStatusMessage();
     String getDomainErrorMessage();
 }

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -33,7 +33,7 @@ public class FollowCommandService {
         }
     }
 
-    public void cancel(Long followerId, Long followeeId) {
+    public void unfollow(Long followerId, Long followeeId) {
         Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
         if (optionalFollow.isEmpty()) {
             // 이미 취소된 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -5,12 +5,14 @@ import com.gorogoro.followandlike.follow.domain.model.Follow;
 import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode.UNFOLLOW_PERMISSION_DENIED;
 
 @Service
+@Transactional
 public class FollowCommandService {
 
     private final FollowRepository followRepository;

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -4,7 +4,6 @@ import com.gorogoro.followandlike.follow.domain.model.Follow;
 import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -17,7 +16,6 @@ public class FollowCommandService {
         this.followRepository = followRepository;
     }
 
-    @Transactional
     public void follow(Long followerId, Long followeeId) {
         Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
         if (optionalFollow.isPresent()) {

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -1,11 +1,14 @@
 package com.gorogoro.followandlike.follow.application;
 
+import com.gorogoro.followandlike.follow.domain.exception.FollowException;
 import com.gorogoro.followandlike.follow.domain.model.Follow;
 import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+
+import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode.UNFOLLOW_PERMISSION_DENIED;
 
 @Service
 public class FollowCommandService {
@@ -28,6 +31,25 @@ public class FollowCommandService {
     public void unfollow(Long followerId, Long followeeId) {
         try {
             followRepository.deleteByFollowerIdAndFolloweeId(followerId, followeeId);
+        } catch (DataIntegrityViolationException e) {
+            // 다른 트랜잭션에서 이미 팔로우 취소가 완료된 경우에도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
+        }
+    }
+
+    public void unfollowById(Long userId, Long followId) {
+        Optional<Follow> optionalFollow = followRepository.findById(followId);
+        if (optionalFollow.isEmpty()) {
+            // 이미 취소된 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
+            return;
+        }
+
+        Follow followFound = optionalFollow.get();
+        if (!followFound.getFollowerId().equals(userId)) {
+            throw new FollowException(UNFOLLOW_PERMISSION_DENIED);
+        }
+
+        try {
+            followRepository.delete(followFound);
         } catch (DataIntegrityViolationException e) {
             // 다른 트랜잭션에서 이미 팔로우 취소가 완료된 경우에도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
         }

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -1,0 +1,49 @@
+package com.gorogoro.followandlike.follow.application;
+
+import com.gorogoro.followandlike.follow.domain.model.Follow;
+import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class FollowCommandService {
+
+    private final FollowRepository followRepository;
+
+    public FollowCommandService(FollowRepository followRepository) {
+        this.followRepository = followRepository;
+    }
+
+    @Transactional
+    public void follow(Long followerId, Long followeeId) {
+        Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
+        if (optionalFollow.isPresent()) {
+            // 이미 존재하는 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 멱등성 보장)
+            return;
+        }
+
+        Follow follow = new Follow(followerId, followeeId);
+        try {
+            followRepository.save(follow);
+        } catch (DataIntegrityViolationException e) {
+            // 다른 트랜잭션에서 이미 팔로우 처리가 완료된 경우에도 문제 없이 넘어가야 함. (팔로우 멱등성 보장)
+        }
+    }
+
+    public void cancel(Long followerId, Long followeeId) {
+        Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
+        if (optionalFollow.isEmpty()) {
+            // 이미 취소된 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
+            return;
+        }
+
+        try {
+            followRepository.deleteByFollowerIdAndFolloweeId(followerId, followeeId);
+        } catch (DataIntegrityViolationException e) {
+            // 다른 트랜잭션에서 이미 팔로우 취소가 완료된 경우에도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
+        }
+    }
+}

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowCommandService.java
@@ -17,12 +17,6 @@ public class FollowCommandService {
     }
 
     public void follow(Long followerId, Long followeeId) {
-        Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
-        if (optionalFollow.isPresent()) {
-            // 이미 존재하는 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 멱등성 보장)
-            return;
-        }
-
         Follow follow = new Follow(followerId, followeeId);
         try {
             followRepository.save(follow);
@@ -32,12 +26,6 @@ public class FollowCommandService {
     }
 
     public void unfollow(Long followerId, Long followeeId) {
-        Optional<Follow> optionalFollow = followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId);
-        if (optionalFollow.isEmpty()) {
-            // 이미 취소된 팔로우에 대해서도 문제 없이 넘어가야 함. (팔로우 취소 멱등성 보장)
-            return;
-        }
-
         try {
             followRepository.deleteByFollowerIdAndFolloweeId(followerId, followeeId);
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
@@ -50,7 +50,7 @@ public class FollowQueryService {
                 .map(FollowResponse::from)
                 .toList();
 
-        return new CursorBasedPaginatedResult<FollowResponse>(
+        return new CursorBasedPaginatedResult<>(
                 responseContent, followings.nextCursor(), followings.hasNext());
     }
 
@@ -62,7 +62,7 @@ public class FollowQueryService {
                 .map(FollowResponse::from)
                 .toList();
 
-        return new CursorBasedPaginatedResult<FollowResponse>(
+        return new CursorBasedPaginatedResult<>(
                 responseContent, followings.nextCursor(), followings.hasNext());
     }
 }

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
@@ -1,0 +1,68 @@
+package com.gorogoro.followandlike.follow.application;
+
+import com.gorogoro.followandlike.follow.application.dto.FollowResponse;
+import com.gorogoro.followandlike.follow.domain.exception.FollowException;
+import com.gorogoro.followandlike.follow.application.dto.CursorBasedPaginatedResult;
+import com.gorogoro.followandlike.follow.domain.model.Follow;
+import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode.FOLLOW_NOT_FOUND;
+
+@Service
+public class FollowQueryService {
+
+    private final FollowRepository followRepository;
+
+    public FollowQueryService(FollowRepository followRepository) {
+        this.followRepository = followRepository;
+    }
+
+    public FollowResponse findById(Long id) {
+        return FollowResponse.from(
+                followRepository.findById(id)
+                        .orElseThrow(() -> new FollowException(FOLLOW_NOT_FOUND))
+        );
+    }
+
+    public FollowResponse findByFollowerIdAndFolloweeId(Long followerId, Long followeeId) {
+        return FollowResponse.from(
+                followRepository.findByFollowerIdAndFolloweeId(followerId, followeeId)
+                        .orElseThrow(() -> new FollowException(FOLLOW_NOT_FOUND))
+        );
+    }
+
+    public long countByFollowerId(Long followerId) {
+        return followRepository.countByFollowerId(followerId);
+    }
+
+    public long countByFolloweeId(Long followeeId) {
+        return followRepository.countByFolloweeId(followeeId);
+    }
+
+    public CursorBasedPaginatedResult<FollowResponse> findFollowings(Long followerId, Long pageCursor, int fetchSize) {
+        CursorBasedPaginatedResult<Follow> followings
+                = followRepository.getFollowings(followerId, pageCursor, fetchSize);
+
+        List<FollowResponse> responseContent = followings.content().stream()
+                .map(FollowResponse::from)
+                .toList();
+
+        return new CursorBasedPaginatedResult<FollowResponse>(
+                responseContent, followings.nextCursor(), followings.hasNext());
+    }
+
+    public CursorBasedPaginatedResult<FollowResponse> findFollowers(Long followeeId, Long pageCursor, int fetchSize) {
+        CursorBasedPaginatedResult<Follow> followings
+                = followRepository.getFollowers(followeeId, pageCursor, fetchSize);
+
+        List<FollowResponse> responseContent = followings.content().stream()
+                .map(FollowResponse::from)
+                .toList();
+
+        return new CursorBasedPaginatedResult<FollowResponse>(
+                responseContent, followings.nextCursor(), followings.hasNext());
+    }
+}

--- a/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/FollowQueryService.java
@@ -6,12 +6,14 @@ import com.gorogoro.followandlike.follow.application.dto.CursorBasedPaginatedRes
 import com.gorogoro.followandlike.follow.domain.model.Follow;
 import com.gorogoro.followandlike.follow.domain.repository.FollowRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static com.gorogoro.followandlike.follow.domain.exception.FollowErrorCode.FOLLOW_NOT_FOUND;
 
 @Service
+@Transactional(readOnly = true)
 public class FollowQueryService {
 
     private final FollowRepository followRepository;

--- a/src/main/java/com/gorogoro/followandlike/follow/application/dto/FollowResponse.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/application/dto/FollowResponse.java
@@ -1,0 +1,17 @@
+package com.gorogoro.followandlike.follow.application.dto;
+
+import com.gorogoro.followandlike.follow.domain.model.Follow;
+
+import java.time.Instant;
+
+public record FollowResponse(
+        Long id,
+        Long followerId,
+        Long followeeId,
+        Instant createdAt
+) {
+
+    public static FollowResponse from(Follow follow) {
+        return new FollowResponse(follow.getId(), follow.getFollowerId(), follow.getFolloweeId(), follow.getCreatedAt());
+    }
+}

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
@@ -24,8 +24,8 @@ public enum FollowErrorCode implements ErrorCode {
 
 
     @Override
-    public int getHttpStatus() {
-        return httpStatus.value();
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
     }
 
     @Override

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
@@ -11,7 +11,7 @@ public enum FollowErrorCode implements ErrorCode {
     FOLLOWEE_ID_IS_NEGATIVE(HttpStatus.BAD_REQUEST, "followeeId 가 음수입니다."),
     FOLLOWED_ONESELF(HttpStatus.BAD_REQUEST, "자기자신을 팔로우할 수 없습니다. followerId 와 followeeId 가 같습니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우를 찾을 수 없습니다."),
-
+    UNFOLLOW_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "다른 회원의 팔로우는 취소할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
@@ -24,7 +24,7 @@ public enum FollowErrorCode implements ErrorCode {
 
 
     @Override
-    public HttpStatus getHttpStatus() {
+    public HttpStatus getHttpStatusCode() {
         return httpStatus;
     }
 

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowErrorCode.java
@@ -1,6 +1,6 @@
 package com.gorogoro.followandlike.follow.domain.exception;
 
-import com.gorogoro.followandlike.common.exception.ErrorCode;
+import com.gorogoro.followandlike.common.domain.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum FollowErrorCode implements ErrorCode {

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowException.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/exception/FollowException.java
@@ -1,7 +1,6 @@
 package com.gorogoro.followandlike.follow.domain.exception;
 
-import com.gorogoro.followandlike.common.exception.BaseDomainException;
-import lombok.Getter;
+import com.gorogoro.followandlike.common.domain.exception.BaseDomainException;
 
 public class FollowException extends BaseDomainException {
 

--- a/src/main/java/com/gorogoro/followandlike/follow/domain/repository/FollowRepository.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/domain/repository/FollowRepository.java
@@ -21,5 +21,7 @@ public interface FollowRepository {
 
     Follow save(Follow follow);
 
+    void delete(Follow follow);
+
     void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 }

--- a/src/main/java/com/gorogoro/followandlike/follow/infrastructure/jpa/FollowRepositoryJpaAdapter.java
+++ b/src/main/java/com/gorogoro/followandlike/follow/infrastructure/jpa/FollowRepositoryJpaAdapter.java
@@ -112,6 +112,11 @@ public class FollowRepositoryJpaAdapter implements FollowRepository {
     }
 
     @Override
+    public void delete(Follow follow) {
+        followJpaRepository.delete(follow);
+    }
+
+    @Override
     public void deleteByFollowerIdAndFolloweeId(Long followerId, Long followeeId) {
         followJpaRepository.deleteByFollowerIdAndFolloweeId(followerId, followeeId);
     }


### PR DESCRIPTION
### 변경 파일
- `FollowCommandService`: 팔로우 및 언팔로우, 멱등성 보장
- `FollowQueryService`: 기본 키 조회, 비즈니스 키 조회, 팔로워 및 팔로잉 수 조회, 팔로워 및 팔로잉 목록 검색(페이징)
- `FollowRepository` & `FollowRepositoryJpaAdapter`: 기본키(id) 로 삭제하는 메서드 추가
- `FollowResponse`: 응답 DTO
- `ErrorCode`: getHttpStatus 메서드 변경
- `FollowErroCode`: 언팔로우 시 필요한 권한 에러 코드 추가

### 단순 패키지 이동(common.exception -> common.domain.exception)
- `BaseDomainException`
- `ErrorCode`
- 위치 이동 import 반영(common.exception -> common.domain.exception)
  - `FollowException`
  - `FollowErrorCode`

closes #15 